### PR TITLE
ci: Implement OpenAPI spec autogeneration using a gradle task

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(24)
 	}
 }
 
@@ -19,8 +19,41 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.register('openApiExport', Test) {
+    group = 'openapi'
+    dependsOn testClasses
+    useJUnitPlatform()
+
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
+    filter {
+        includeTestsMatching 'com.example.OpenApiExportTest'
+    }
+
+    outputs.upToDateWhen { false }
+
+    doFirst {
+        println "======================================================"
+        println "------- GENERATING OPENAPI SPEC (openapi.yaml) -------"
+        println "======================================================"
+    }
+
+    doLast {
+        def openapiFile = file("$projectDir/openapi.yaml")
+        if (openapiFile.exists()) {
+            println "openapi.yaml generated successfully at $openapiFile"
+        } else {
+            println "WARNING: openapi.yaml was NOT generated!"
+        }
+    }
 }

--- a/BE/settings.gradle
+++ b/BE/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'backend-api'
+rootProject.name = 'BE'

--- a/BE/src/main/java/com/example/examples/OpenAPI.java
+++ b/BE/src/main/java/com/example/examples/OpenAPI.java
@@ -1,0 +1,28 @@
+package com.example.examples;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.stream.IntStream;
+
+@RestController
+@RequestMapping("/example/openapi")
+public class OpenAPI {
+    @Operation(summary = "Get a book by its id")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Integers returned successfully",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = Integer.class))})
+    })
+    @GetMapping
+    public ResponseEntity<Integer[]> getAnIntegerArray() {
+        return ResponseEntity.ok(IntStream.range(0, 10).boxed().toArray(Integer[]::new));
+    }
+}

--- a/BE/src/main/resources/application.properties
+++ b/BE/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-server.port=8080

--- a/BE/src/main/resources/application.yaml
+++ b/BE/src/main/resources/application.yaml
@@ -1,0 +1,9 @@
+spring:
+  application:
+    name: BE
+
+springdoc:
+  api-docs:
+    version: openapi_3_0
+  swagger-ui:
+    path: /swagger-ui.html

--- a/BE/src/test/java/com/example/OpenApiExportTest.java
+++ b/BE/src/test/java/com/example/OpenApiExportTest.java
@@ -1,0 +1,22 @@
+package com.example;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class OpenApiExportTest {
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void exportOpenApi() throws Exception {
+        String spec = restTemplate.getForObject("/v3/api-docs", String.class);
+        Files.write(Paths.get("openapi.yaml"), spec.getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
Includes:
- An endpoint to view the generated spec in a nice UI (see application.yaml for path)
- An example on how to use it to annotate endpoints
- A task that can generate that file using a test (plugin would require one to manually start and shut off the backend, but the current approach only requires the execution of a short gradle task)

**Additionally:**
- Renamed application.properties to application.yaml for easier perusing of the properties file (useful for later)
- Renamed gradle rootProject name appropriately
- Upgraded gradle to compile Java24

Refs: https://app.clickup.com/t/86c6eqevb