### PR TITLE
Fe/extract navbar to app root

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -5,11 +5,12 @@ import { ToastContainer } from "react-toastify";
 import { BrowserRouter, useLocation } from "react-router-dom";
 import { AuthProvider } from "./authentication/AuthContext";
 import { TopNav } from "./components/TopNav";
+import { ROUTES } from "./routing/routes";
 import "react-toastify/dist/ReactToastify.css";
 
 function AppContent() {
   const location = useLocation();
-  const isLoginOrRegister = location.pathname === '/login' || location.pathname === '/register';
+  const isLoginOrRegister = [ROUTES.login, ROUTES.register].includes(location.pathname);
 
   return (
     <>

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -2,16 +2,29 @@ import { ThemeProvider } from "@emotion/react";
 import AppRouting from "./routing/AppRouting";
 import theme from "./theme";
 import { ToastContainer } from "react-toastify";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, useLocation } from "react-router-dom";
 import { AuthProvider } from "./authentication/AuthContext";
+import { TopNav } from "./components/TopNav";
 import "react-toastify/dist/ReactToastify.css";
+
+function AppContent() {
+  const location = useLocation();
+  const isLoginOrRegister = location.pathname === '/login' || location.pathname === '/register';
+
+  return (
+    <>
+      {!isLoginOrRegister && <TopNav />}
+      <AppRouting />
+    </>
+  );
+}
 
 function App() {
   return (
     <ThemeProvider theme={theme}>
       <AuthProvider>
         <BrowserRouter>
-          <AppRouting />
+          <AppContent />
         </BrowserRouter>
         <ToastContainer 
           containerId="global-toast"

--- a/FE/src/components/ManageTask/Form.tsx
+++ b/FE/src/components/ManageTask/Form.tsx
@@ -13,6 +13,7 @@ import { TaskFormSchema } from "../../lib/zod";
 import SaveIcon from "@mui/icons-material/Save";
 import DependencyFormInput from "./DependencyFormInput";
 import { toast } from "react-toastify";
+import { ROUTES } from "../../routing/routes";
 
 const maxDamage = 20;
 const maxProcrastinationDamage = 10;
@@ -127,7 +128,7 @@ export default function Form() {
             await taskApi.add(request);
         }
         
-        navigate("/home");
+        navigate(ROUTES.home);
     };
     
     return (

--- a/FE/src/components/TaskDetails/TaskCard.tsx
+++ b/FE/src/components/TaskDetails/TaskCard.tsx
@@ -15,6 +15,7 @@ import { StatusDropdown } from "../Generic/StatusDropdown";
 import { toast } from "react-toastify";
 import { allCategories } from "../../lib/status";
 import { fontFamilyStyle, fontSizeStyle } from "../../lib/style";
+import { ROUTES } from "../../routing/routes";
 
 export default function TaskCard({id}: {id: number}) {
     const navigate = useNavigate(); 
@@ -94,7 +95,7 @@ export default function TaskCard({id}: {id: number}) {
         }
         setOpenDialog(false);
 
-        navigate("/");
+        navigate(ROUTES.root);
     };
 
     const handleTakeTaskClick = async () => {

--- a/FE/src/components/TopNav.tsx
+++ b/FE/src/components/TopNav.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { Typography, Box, Menu, MenuItem } from '@mui/material';
 import { fontFamilyStyle, fontSizeStyle } from '../lib/style';
 import { ROUTES } from '../routing/routes';
+import '../styles/global.css';
 
 export const TopNav = () => {
   const segments = 10;
@@ -86,15 +87,12 @@ export const TopNav = () => {
       sx={{
         display: 'flex',
         justifyContent: 'space-between',
-        alignItems: 'center',
-        height: 64,
-        bgcolor: '#fff',
-        borderBottom: '1px solid #e6e6e6',
+        height: 'var(--navbar-height)',
+        width: 'auto',
+        inset: 0,
         px: 2,
+        bgcolor: '#ffffff',
         position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
         zIndex: 1000,
       }}
     >

--- a/FE/src/components/TopNav.tsx
+++ b/FE/src/components/TopNav.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '../authentication/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { Typography, Box, Menu, MenuItem } from '@mui/material';
 import { fontFamilyStyle, fontSizeStyle } from '../lib/style';
+import { ROUTES } from '../routing/routes';
 
 export const TopNav = () => {
   const segments = 10;
@@ -39,7 +40,7 @@ export const TopNav = () => {
   const handleLogout = () => {
     handleUserMenuClose();
     logout();
-    navigate('/login');
+    navigate(ROUTES.login);
   };
 
   const handleAdminPanel = () => {
@@ -90,11 +91,16 @@ export const TopNav = () => {
         bgcolor: '#fff',
         borderBottom: '1px solid #e6e6e6',
         px: 2,
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 1000,
       }}
     >
       {/* BRAND SECTION */}
       <Box
-        onClick={() => navigate('/')}
+        onClick={() => navigate(ROUTES.root)}
         sx={{
           display: 'flex',
           alignItems: 'center',
@@ -105,7 +111,7 @@ export const TopNav = () => {
         <Box component="img" src={logoSvg} alt="TUDU Logo" sx={{ height: 28, display: 'block' }} />
         <Typography
           variant="h5"
-          sx={[fontFamilyStyle, 
+          sx={[fontFamilyStyle,
           {
             fontWeight: 400,
             fontSize: '36px',
@@ -218,9 +224,9 @@ export const TopNav = () => {
             }}
           >
             {isAdmin && (
-              <MenuItem 
+              <MenuItem
                 onClick={handleAdminPanel}
-                sx={[fontFamilyStyle, fontSizeStyle, 
+                sx={[fontFamilyStyle, fontSizeStyle,
                 {
                   display: 'block',
                   width: '100%',
@@ -236,7 +242,7 @@ export const TopNav = () => {
                 Admin Panel
               </MenuItem>
             )}
-            <MenuItem 
+            <MenuItem
               onClick={handleLogout}
               sx={[fontFamilyStyle, fontSizeStyle, {
                 display: 'block',

--- a/FE/src/components/TopNav.tsx
+++ b/FE/src/components/TopNav.tsx
@@ -10,14 +10,9 @@ import { useNavigate } from 'react-router-dom';
 import { Typography, Box, Menu, MenuItem } from '@mui/material';
 import { fontFamilyStyle, fontSizeStyle } from '../lib/style';
 
-interface TopNavProps {
-  energyLevel: number; // 0-10 segments
-  onDecrease?: () => void;
-  onIncrease?: () => void;
-}
-
-export const TopNav = ({ energyLevel, onDecrease, onIncrease }: TopNavProps) => {
+export const TopNav = () => {
   const segments = 10;
+  const [energyLevel, setEnergyLevel] = useState(6);
   const atMin = energyLevel <= 0;
   const atMax = energyLevel >= segments;
   const { logout, isAdmin } = useAuth();
@@ -31,6 +26,14 @@ export const TopNav = ({ energyLevel, onDecrease, onIncrease }: TopNavProps) => 
 
   const handleUserMenuClose = () => {
     setAnchorEl(null);
+  };
+
+  const handleDecrease = () => {
+    setEnergyLevel(prev => Math.max(0, prev - 1));
+  };
+
+  const handleIncrease = () => {
+    setEnergyLevel(prev => Math.min(10, prev + 1));
   };
 
   const handleLogout = () => {
@@ -120,7 +123,7 @@ export const TopNav = ({ energyLevel, onDecrease, onIncrease }: TopNavProps) => 
         {/* Decrease Button */}
         <Box
           component="button"
-          onClick={onDecrease}
+          onClick={handleDecrease}
           disabled={atMin}
           aria-label="Decrease energy"
           sx={circleBtnStyle(atMin)}
@@ -166,7 +169,7 @@ export const TopNav = ({ energyLevel, onDecrease, onIncrease }: TopNavProps) => 
         {/* Increase Button */}
         <Box
           component="button"
-          onClick={onIncrease}
+          onClick={handleIncrease}
           disabled={atMax}
           aria-label="Increase energy"
           sx={circleBtnStyle(atMax)}

--- a/FE/src/index.css
+++ b/FE/src/index.css
@@ -1,61 +1,61 @@
 @import url("https://fonts.googleapis.com/css2?family=Nanum+Pen+Script&display=swap");
 
 * {
-  margin: 0 !important;
-  padding: 0 !important;
-  box-sizing: border-box;
+    margin: 0 !important;
+    padding: 0 !important;
+    box-sizing: border-box;
 }
 
 :root {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Source Sans Pro',
     sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-  color: #1a1a1a;
-  background-color: #f9f9f9;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+    line-height: 1.5;
+    font-weight: 400;
+    color: #1a1a1a;
+    background-color: #f9f9f9;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 html,
 body,
 #root {
-  margin: 0 !important;
-  padding: 0 !important;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
+    margin: 0 !important;
+    padding: 0 !important;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
 }
 
 a {
-  color: #4f46e5;
-  text-decoration: none;
+    color: #4f46e5;
+    text-decoration: none;
 }
 
 a:hover {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 
 button {
-  font-family: inherit;
+    font-family: inherit;
 }
 
 :focus-visible {
-  outline: 2px solid #4f46e5;
-  outline-offset: 2px;
+    outline: 2px solid #4f46e5;
+    outline-offset: 2px;
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Source Sans Pro',
     sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 .nanum-pen {
-  font-family: 'Nanum Pen Script', cursive !important;
+    font-family: 'Nanum Pen Script', cursive !important;
 }

--- a/FE/src/pages/AdminPanel.tsx
+++ b/FE/src/pages/AdminPanel.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { TopNav } from '../components/TopNav';
 import { StatusDropdown } from '../components/Generic/StatusDropdown';
 import { Typography, Box } from '@mui/material';
 import { taskApi, userApi } from '../api/api';
@@ -14,7 +13,7 @@ import { QuestCard } from '../components/QuestCard';
 import { formatDate } from '../lib/date';
 import { TasksChart } from '../components/AdminPanel/TasksChart';
 import { unAssignableCategories } from '../lib/status';
-import { fontFamilyStyle, fontSizeStyle } from '../lib/style';
+import { fontFamilyStyle } from '../lib/style';
 
 export const AdminPanel = () => {
   const [drawerItems, setDrawerItems] = useState<DrawerItem[]>([]);
@@ -29,8 +28,6 @@ export const AdminPanel = () => {
 
   const [userCompletedTasks, setUserCompletedTasks] = useState<number>(0);
   const [userTotalTasks, setUserTotalTasks] = useState<number>(0);
-
-  const [energyLevel, setEnergyLevel] = useState(6);
 
   const handleSelect = (status: TaskDTOStatusEnum) => {
     setSelected(status);
@@ -175,12 +172,7 @@ export const AdminPanel = () => {
   }, [userId]);
 
   return (
-    <Box sx={{display: 'flex', flexDirection: 'column', height: '100vh', width: '100vw', bgcolor: '#A8B1FF', m: 0, p: 0}}>
-      <TopNav
-        energyLevel={energyLevel}
-        onDecrease={() => setEnergyLevel(prev => Math.max(0, prev - 1))}
-        onIncrease={() => setEnergyLevel(prev => Math.min(10, prev + 1))}
-      />
+    <Box sx={{display: 'flex', flexDirection: 'column', position: 'fixed', top: 'var(--navbar-height)', height: 'calc(100vh - var(--navbar-height))', width: '100vw', bgcolor: '#A8B1FF', m: 0, p: 0}}>
       <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
         <PermanentDrawerLeft items={drawerItems} onItemClick={onItemClick} selectedItemId={userId}>
           <Box sx={{display: 'flex', bgcolor: '#A8B1FF', flex: 1, height: '100%'}}>

--- a/FE/src/pages/Home.tsx
+++ b/FE/src/pages/Home.tsx
@@ -17,8 +17,6 @@ export const Home = () => {
   const [tasks, setTasks] = useState<TaskDTO[]>([]);
   const [selected, setSelected] = useState<TaskDTOStatusEnum>(TaskDTOStatusEnum.Backlog);
 
-  const [energyLevel, setEnergyLevel] = useState(6);
-
   const handleSelect = (status: TaskDTOStatusEnum) => {
     setSelected(status);
   };
@@ -60,11 +58,6 @@ export const Home = () => {
         left: 0,
       }}
     >
-      <TopNav
-        energyLevel={energyLevel}
-        onDecrease={() => setEnergyLevel(prev => Math.max(0, prev - 1))}
-        onIncrease={() => setEnergyLevel(prev => Math.min(10, prev + 1))}
-      />
       <Box
         sx={{
           position: 'relative',

--- a/FE/src/pages/Home.tsx
+++ b/FE/src/pages/Home.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { TopNav } from '../components/TopNav';
 import { StatusDropdown } from '../components/Generic/StatusDropdown';
 import { QuestCard } from '../components/QuestCard';
 import { Fab } from '../components/Fab';
@@ -47,14 +46,14 @@ export const Home = () => {
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        height: '100vh',
+        height: 'calc(100vh - var(--navbar-height))',
         width: '100vw',
         bgcolor: '#fff',
         m: 0,
         p: 0,
         overflow: 'hidden',
         position: 'fixed',
-        top: 0,
+        top: 'var(--navbar-height)',
         left: 0,
       }}
     >
@@ -123,13 +122,13 @@ export const Home = () => {
           }}
         >
           {inSelected.map((item) => (
+            // TODO(MC): Replace this with TaskCard. Tweak TaskCard to be used here as well
             <QuestCard
               key={item.id}
               id={item.id || 0}
               title={item?.title || ''}
               created={formatDate(item?.creationDate || new Date())}
               deadline={formatDate(item?.deadline || new Date())}
-              width='250px'
               count={item?.energyCost || 0}
             />
           ))}

--- a/FE/src/pages/Login.tsx
+++ b/FE/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { Box, Button, TextField, Typography, Paper } from '@mui/material';
 import { userApi } from '../api/api.ts';
 import { useAuth } from '../authentication/AuthContext';
 import { toast } from 'react-toastify';
+import { ROUTES } from '../routing/routes';
 import { fontFamilyStyle, fontSizeStyle } from '../lib/style.ts';
 
 export default function Login() {
@@ -23,7 +24,7 @@ export default function Login() {
         localStorage.setItem('jwt', response.token);
         await refreshAuth();
         toast.success('Login successful!', { containerId: 'global-toast' });
-        navigate('/home');
+        navigate(ROUTES.home);
       } else {
         throw new Error('Invalid response from server - no token received');
       }
@@ -62,7 +63,7 @@ export default function Login() {
           component="h1" 
           gutterBottom 
           align="center"
-          sx={[fontFamilyStyle, { 
+          sx={[fontFamilyStyle, {
             fontWeight: 600,
             color: '#333',
             mb: 3 
@@ -132,7 +133,7 @@ export default function Login() {
               variant="contained"
               size="large"
               disabled={loading}
-              sx={[fontFamilyStyle, fontSizeStyle, { 
+              sx={[fontFamilyStyle, fontSizeStyle, {
                 mt: 2,
                 mb: 3,
                 py: 1.5,
@@ -159,9 +160,9 @@ export default function Login() {
               Don't have an account?{' '}
               <Button
                 variant="text"
-                onClick={() => navigate('/register')}
+                onClick={() => navigate(ROUTES.register)}
                 disabled={loading}
-                sx={[fontFamilyStyle, fontSizeStyle, { 
+                sx={[fontFamilyStyle, fontSizeStyle, {
                   textTransform: 'none',
                   p: 0,
                   minWidth: 'auto',

--- a/FE/src/pages/Register.tsx
+++ b/FE/src/pages/Register.tsx
@@ -4,6 +4,7 @@ import { Box, Button, TextField, Typography, Paper } from '@mui/material';
 import { userApi } from '../api/api.ts';
 import { toast } from 'react-toastify';
 import { z } from 'zod';
+import { ROUTES } from '../routing/routes';
 import { fontFamilyStyle, fontSizeStyle } from '../lib/style.ts';
 
 const registerSchema = z.object({
@@ -64,7 +65,7 @@ export default function Register() {
       await userApi.register({registerRequest: {username, password, email}});
       toast.success('Registration successful! Please login.', { containerId: 'global-toast' });
       setTimeout(() => {
-        navigate('/login');
+        navigate(ROUTES.login);
       }, 1000);
     } catch (err: any) {
       toast.error(err.message || 'Registration failed. Please try again.', { containerId: 'global-toast' });
@@ -100,7 +101,7 @@ export default function Register() {
           component="h1" 
           gutterBottom 
           align="center"
-          sx={[fontFamilyStyle, { 
+          sx={[fontFamilyStyle, {
             fontWeight: 600,
             color: '#333',
             mb: 3 
@@ -196,7 +197,7 @@ export default function Register() {
               variant="contained"
               size="large"
               disabled={loading}
-              sx={[fontFamilyStyle, fontSizeStyle, { 
+              sx={[fontFamilyStyle, fontSizeStyle, {
                 mt: 2,
                 mb: 3,
                 py: 1.5,
@@ -223,9 +224,9 @@ export default function Register() {
               Already have an account?{' '}
               <Button
                 variant="text"
-                onClick={() => navigate('/login')}
+                onClick={() => navigate(ROUTES.login)}
                 disabled={loading}
-                sx={[fontFamilyStyle, fontSizeStyle, { 
+                sx={[fontFamilyStyle, fontSizeStyle, {
                   textTransform: 'none',
                   p: 0,
                   minWidth: 'auto',

--- a/FE/src/pages/TaskDetailPage.tsx
+++ b/FE/src/pages/TaskDetailPage.tsx
@@ -10,10 +10,10 @@ export function TaskDetailPage() {
     return (
         <Box sx={{
           position: 'fixed',
-          top: 64,
+          top: 'var(--navbar-height)',
           left: 0,
           width: '100vw',
-          height: 'calc(100vh - 64px)',
+          height: 'calc(100vh - var(--navbar-height))',
           display: 'flex',
           flexDirection: 'column',
           bgcolor: '#9FAFFF',

--- a/FE/src/pages/TaskDetailPage.tsx
+++ b/FE/src/pages/TaskDetailPage.tsx
@@ -1,23 +1,19 @@
 import Box from "@mui/material/Box";
-import { TopNav } from "../components/TopNav";
-import { useState } from "react";
 import notesIcon from "../assets/notes.png"
 import treeIcon from "../assets/tree.png"
 import TaskCard from "../components/TaskDetails/TaskCard";
 import { useParams } from "react-router-dom";
 
 export function TaskDetailPage() {
-  const [energyLevel, setEnergyLevel] = useState(6);
-
   const {id} = useParams<{id: string}>();
 
     return (
         <Box sx={{
           position: 'fixed',
-          top: 0,
+          top: 64,
           left: 0,
           width: '100vw',
-          height: '100vh',
+          height: 'calc(100vh - 64px)',
           display: 'flex',
           flexDirection: 'column',
           bgcolor: '#9FAFFF',
@@ -25,12 +21,6 @@ export function TaskDetailPage() {
           padding: 0,
           overflow: 'hidden'
         }}>
-            <TopNav
-                energyLevel={energyLevel}
-                onDecrease={() => setEnergyLevel(prev => Math.max(0, prev - 1))}
-                onIncrease={() => setEnergyLevel(prev => Math.min(10, prev + 1))}
-            />
-            
             <Box sx={{ display: 'flex', flex: 1, position: 'relative', overflow: 'auto'}}>
                 <Box sx={{ width: '600px', display: 'flex', flexDirection: 'column', paddingTop: 2}}>
                     <Box sx={{ px: 3, pb: 2 }}>

--- a/FE/src/pages/TaskForm.tsx
+++ b/FE/src/pages/TaskForm.tsx
@@ -1,19 +1,15 @@
-import { useState } from "react";
-import { TopNav } from "../components/TopNav";
 import Box from "@mui/material/Box";
 import Form from "../components/ManageTask/Form";
 
 export default function TaskForm() {
-  const [energyLevel, setEnergyLevel] = useState(6);
-
   return (
     <Box
       sx={{
         position: "fixed",
-        top: 0,
+        top: 64,
         left: 0,
         width: "100vw",
-        height: "100vh",
+        height: "calc(100vh - 64px)",
         display: "flex",
         flexDirection: "column",
         bgcolor: "#9FAFFF",
@@ -22,11 +18,6 @@ export default function TaskForm() {
         overflow: "hidden",
       }}
     >
-      <TopNav
-        energyLevel={energyLevel}
-        onDecrease={() => setEnergyLevel((prev) => Math.max(0, prev - 1))}
-        onIncrease={() => setEnergyLevel((prev) => Math.min(10, prev + 1))}
-      />
       <Form />
     </Box>
   );

--- a/FE/src/pages/TaskForm.tsx
+++ b/FE/src/pages/TaskForm.tsx
@@ -6,10 +6,10 @@ export default function TaskForm() {
     <Box
       sx={{
         position: "fixed",
-        top: 64,
+        top: 'var(--navbar-height)',
         left: 0,
         width: "100vw",
-        height: "calc(100vh - 64px)",
+        height: "calc(100vh - var(--navbar-height))",
         display: "flex",
         flexDirection: "column",
         bgcolor: "#9FAFFF",

--- a/FE/src/routing/AppRouting.tsx
+++ b/FE/src/routing/AppRouting.tsx
@@ -9,6 +9,7 @@ import Login from "../pages/Login";
 import Register from "../pages/Register";
 import TaskForm from "../pages/TaskForm";
 import { TaskDetailPage } from "../pages/TaskDetailPage";
+import { ROUTES } from "./routes";
 import { AdminPanel } from "../pages/AdminPanel";
 
 const loadingPageSx = {
@@ -54,11 +55,11 @@ function AppRouting() {
   if (authenticated) {
     return (
       <Routes>
-        <Route path="/" element={<Navigate to="/home" replace />} />
-        <Route path="/login" element={<Navigate to="/home" replace />} />
-        <Route path="/register" element={<Navigate to="/home" replace />} />
+        <Route path={ROUTES.root} element={<Navigate to={ROUTES.home} replace />} />
+        <Route path={ROUTES.login} element={<Navigate to={ROUTES.home} replace />} />
+        <Route path={ROUTES.register} element={<Navigate to={ROUTES.home} replace />} />
         <Route
-          path="/home"
+          path={ROUTES.home}
           element={
             <RequireAuth>
               <Home />
@@ -66,7 +67,7 @@ function AppRouting() {
           }
         />
         <Route
-          path="/manage-task/:id?"
+          path={`${ROUTES.manageTask}/:id?`}
           element={
             <RequireAuth>
               <TaskForm />
@@ -75,7 +76,7 @@ function AppRouting() {
 
         </Route>
         <Route
-          path="/task/:id"
+          path={`${ROUTES.task}/:id`}
           element={
             <RequireAuth>
               <TaskDetailPage />
@@ -90,7 +91,7 @@ function AppRouting() {
             </RequireAdmin>
           }>
         </Route>
-        <Route path="*" element={<Navigate to="/" replace />} />
+        <Route path="*" element={<Navigate to={ROUTES.root} replace />} />
       </Routes>
     );
   }
@@ -98,14 +99,14 @@ function AppRouting() {
   return (
     <Box sx={authPageSx}>
       <Routes>
-        <Route path="/" element={<Navigate to="/login" replace />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/register" element={<Register />} />
-        <Route path="/home" element={<Navigate to="/login" replace />} />
-        <Route path="/manage-task/:id?" element={<Navigate to="/login" replace />} />
-        <Route path="/task/:id" element={<Navigate to="/login" replace />} />
+        <Route path={ROUTES.root} element={<Navigate to={ROUTES.login} replace />} />
+        <Route path={ROUTES.login} element={<Login />} />
+        <Route path={ROUTES.register} element={<Register />} />
+        <Route path={ROUTES.home} element={<Navigate to={ROUTES.login} replace />} />
+        <Route path={`${ROUTES.manageTask}/:id?`} element={<Navigate to={ROUTES.login} replace />} />
+        <Route path={`${ROUTES.task}/:id`} element={<Navigate to={ROUTES.login} replace />} />
         <Route path="/admin" element={<Navigate to="/login" replace />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
+        <Route path="*" element={<Navigate to={ROUTES.root} replace />} />
 
       </Routes>
     </Box>

--- a/FE/src/routing/routes.ts
+++ b/FE/src/routing/routes.ts
@@ -1,0 +1,17 @@
+export const ROUTES = {
+  home: '/home',
+  login: '/login',
+  register: '/register',
+  manageTask: '/manage-task',
+  task: '/task',
+  root: '/',
+} as const;
+
+export const getManageTaskRoute = (id?: number | string) => {
+  return id ? `${ROUTES.manageTask}/${id}` : ROUTES.manageTask;
+};
+
+export const getTaskRoute = (id: number | string) => {
+  return `${ROUTES.task}/${id}`;
+};
+

--- a/FE/src/styles/global.css
+++ b/FE/src/styles/global.css
@@ -1,0 +1,3 @@
+:root {
+    --navbar-height: 7vh;
+}


### PR DESCRIPTION
Refactored the TopNav component to eliminate code duplication across
pages by moving it to the App root level. The component now manages
its own energy level state internally, removing the need for props.