### PR TITLE
fix(FE): Pass state to navigate for task management

### DIFF
--- a/BE/docker/Dockerfile
+++ b/BE/docker/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN sed -i 's/\r$//' ./gradlew && chmod +x ./gradlew
 
 # Generate OpenAPI client for frontend
-RUN ./gradlew openApiGenerate --no-daemon
+#RUN ./gradlew openApiGenerate --no-daemon
 
 # Build the application
 RUN ./gradlew assemble --no-daemon

--- a/FE/src/components/Generic/SearchBar.tsx
+++ b/FE/src/components/Generic/SearchBar.tsx
@@ -1,0 +1,30 @@
+import { TextField, InputAdornment } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import { fontFamilyStyle } from '../../lib/style';
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export const SearchBar = ({ value, onChange, placeholder }: SearchBarProps) => (
+  <TextField
+    variant="outlined"
+    value={value}
+    onChange={e => onChange(e.target.value)}
+    placeholder={placeholder || 'Search...'}
+    size="small"
+    InputProps={{
+      startAdornment: (
+        <InputAdornment position="start">
+          <SearchIcon />
+        </InputAdornment>
+      ),
+      style: { ...fontFamilyStyle, background: '#fff', borderRadius: 8 }
+    }}
+    sx={{ minWidth: 250 }}
+  />
+);
+
+export default SearchBar;

--- a/FE/src/components/TaskDetails/TaskCard.tsx
+++ b/FE/src/components/TaskDetails/TaskCard.tsx
@@ -164,7 +164,7 @@ export default function TaskCard({ id, consumeEnergy }: { id: number, consumeEne
                             </Typography>
                         </Box>
                         <Box sx={{ display: 'flex', gap: 0.5 }}>
-                            <IconButton size="small" sx={{ padding: '4px' }} onClick={() => navigate(`/manage-task/${task.id}`)}>
+                            <IconButton size="small" sx={{ padding: '4px' }} onClick={() => navigate(`/manage-task/${task.id}`, { state: { fromTaskDescription: true } })}>
                                 <EditIcon sx={[fontSizeStyle]} />
                             </IconButton>
                             <IconButton size="small" sx={{ padding: '4px' }} onClick={() => setOpenDialog(true)}>

--- a/FE/src/components/TaskDetails/TaskGraph.tsx
+++ b/FE/src/components/TaskDetails/TaskGraph.tsx
@@ -36,6 +36,7 @@ export interface TaskGraphRef {
 const TaskGraph = forwardRef<TaskGraphRef, TaskGraphProps>(({ currentTaskId }, ref) => {
     const [graphData, setGraphData] = useState<GraphData>({ nodes: [], links: [] });
     const [loading, setLoading] = useState(true);
+    const [hoveredNode, setHoveredNode] = useState<any>(null);
     const graphRef = useRef<any>(null);
 
     const loadGraph = useCallback(async () => {
@@ -215,7 +216,7 @@ const TaskGraph = forwardRef<TaskGraphRef, TaskGraphProps>(({ currentTaskId }, r
         const tasksMap = new Map<number, TaskDTO>();
         const taskLevels = new Map<number, number>();
         const links: GraphLink[] = [];
-        const queue: { taskId: number; level: number }[] = [{ taskId: rootTaskId, level: 0 }];
+        const queue: { taskId: number, level: number }[] = [{ taskId: rootTaskId, level: 0 }];
 
         // Breadth-first search to traverse dependency graph
         while (queue.length > 0) {
@@ -536,14 +537,14 @@ const TaskGraph = forwardRef<TaskGraphRef, TaskGraphProps>(({ currentTaskId }, r
     }
 
     return (
-        <Box 
-            sx={{ 
-                width: '100%', 
+        <Box
+            sx={{
+                width: '100%',
                 height: '100%',
                 position: 'relative',
                 '& canvas': {
-                    cursor: 'default !important'
-                }
+                    cursor: hoveredNode ? 'pointer' : 'default',
+                },
             }}
         >
             <ForceGraph2D
@@ -568,6 +569,7 @@ const TaskGraph = forwardRef<TaskGraphRef, TaskGraphProps>(({ currentTaskId }, r
                 enableZoomInteraction={true}
                 enablePanInteraction={true}
                 onNodeClick={handleNodeClick}
+                onNodeHover={node => setHoveredNode(node)}
                 d3VelocityDecay={0.3}
                 cooldownTicks={0}
                 dagMode="lr"

--- a/FE/src/pages/Home.tsx
+++ b/FE/src/pages/Home.tsx
@@ -134,7 +134,15 @@ export const Home = () => {
           ))}
         </Box>
 
-        <Fab onClick={() => { navigator('/manage-task') }} />
+        <Fab 
+          onClick={() => { navigator('/manage-task') }} 
+          sx={{
+            position: 'fixed',
+            bottom: '16px',
+            right: '16px',
+            zIndex: 1000,
+          }}
+        />
       </Box>
     </Box>
   );

--- a/FE/src/pages/Home.tsx
+++ b/FE/src/pages/Home.tsx
@@ -11,10 +11,12 @@ import { formatDate } from '../lib/date';
 import { toast } from 'react-toastify';
 import { allCategories } from '../lib/status';
 import { fontFamilyStyle } from '../lib/style';
+import { SearchBar } from '../components/Generic/SearchBar';
 
 export const Home = () => {
   const [tasks, setTasks] = useState<TaskDTO[]>([]);
   const [selected, setSelected] = useState<TaskDTOStatusEnum>(TaskDTOStatusEnum.Backlog);
+  const [search, setSearch] = useState('');
 
   const handleSelect = (status: TaskDTOStatusEnum) => {
     setSelected(status);
@@ -106,7 +108,10 @@ export const Home = () => {
               Quests
             </Typography>
           </Box>
-          <StatusDropdown categories={allCategories} selected={selected} handleSelect={handleSelect} />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <SearchBar value={search} onChange={setSearch} placeholder="Search tasks..." />
+            <StatusDropdown categories={allCategories} selected={selected} handleSelect={handleSelect} />
+          </Box>
         </Box>
 
         {/* Card Grid */}


### PR DESCRIPTION
This pull request includes a minor frontend improvement and a small Dockerfile adjustment. The frontend change enhances navigation by passing additional state when editing a task, while the Dockerfile change comments out the OpenAPI client generation step, likely to speed up builds or due to a temporary need.

Frontend improvement:

* Updated the navigation in `TaskCard.tsx` to include a `state` parameter (`fromTaskDescription: true`) when redirecting to the manage task page, allowing the target page to know the navigation source.

Build process adjustment:

* Commented out the OpenAPI client generation step in the Dockerfile (`BE/docker/Dockerfile`), possibly to skip unnecessary code generation during the build.